### PR TITLE
Outiedorfling/seperate pgsql specific migrations

### DIFF
--- a/app/Libraries/Helper/DatabaseLibrary.php
+++ b/app/Libraries/Helper/DatabaseLibrary.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 
 class DatabaseLibrary
 {
-    public static function removeUpdatedAtFunction(): void
+    public static function removePgsqlUpdatedAtFunction(): void
     {
         DB::statement(
         /** @lang PostgreSQL */
@@ -14,7 +14,7 @@ class DatabaseLibrary
         );
     }
 
-    public static function createUpdatedAtFunction(): void
+    public static function createPgsqlUpdatedAtFunction(): void
     {
         DB::statement(
         /** @lang PostgreSQL */

--- a/app/Models/Enum/DatabaseEnum.php
+++ b/app/Models/Enum/DatabaseEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Models\Enum;
+
+class DatabaseEnum
+{
+    public const DB_POSTGRESQL = 'pgsql';
+}

--- a/config/database.php
+++ b/config/database.php
@@ -67,7 +67,7 @@ return [
             ) : [],
         ],
 
-        'pgsql' => [
+        \App\Models\Enum\DatabaseEnum::DB_POSTGRESQL => [
             'driver' => 'pgsql',
             'url' => env('DATABASE_URL'),
             'write' => [

--- a/database/migrations/1900_01_01_000001_add_uuid_extension_to_postgresql.php
+++ b/database/migrations/1900_01_01_000001_add_uuid_extension_to_postgresql.php
@@ -1,4 +1,6 @@
 <?php
+
+use \App\Models\Enum\DatabaseEnum;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -9,11 +11,17 @@ class AddUuidExtensionToPostgresql extends Migration
 
     public function up()
     {
-        DB::statement('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+        //Only run this when we are using postgresql
+        if (env('DB_CONNECTION') === DatabaseEnum::DB_POSTGRESQL) {
+            DB::statement('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+        }
     }
 
     public function down()
     {
-        DB::statement('DROP EXTENSION IF EXISTS "uuid-ossp";');
+        //Only run this when we are using postgresql
+        if (env('DB_CONNECTION') === DatabaseEnum::DB_POSTGRESQL) {
+            DB::statement('DROP EXTENSION IF EXISTS "uuid-ossp";');
+        }
     }
 }

--- a/database/migrations/1900_01_01_000005_add_update_timestamp_function.php
+++ b/database/migrations/1900_01_01_000005_add_update_timestamp_function.php
@@ -1,5 +1,6 @@
 <?php
 
+use \App\Models\Enum\DatabaseEnum;
 use Illuminate\Database\Migrations\Migration;
 
 class AddUpdateTimestampFunction extends Migration
@@ -7,11 +8,17 @@ class AddUpdateTimestampFunction extends Migration
 
     public function up()
     {
+        //Only run this when we are using postgresql
+        if (env('DB_CONNECTION') === DatabaseEnum::DB_POSTGRESQL) {
             \App\Libraries\Helper\DatabaseLibrary::createPgsqlUpdatedAtFunction();
+        }
     }
 
     public function down()
     {
+        //Only run this when we are using postgresql
+        if (env('DB_CONNECTION') === DatabaseEnum::DB_POSTGRESQL) {
             \App\Libraries\Helper\DatabaseLibrary::removePgsqlUpdatedAtFunction();
+        }
     }
 }

--- a/database/migrations/1900_01_01_000005_add_update_timestamp_function.php
+++ b/database/migrations/1900_01_01_000005_add_update_timestamp_function.php
@@ -7,11 +7,11 @@ class AddUpdateTimestampFunction extends Migration
 
     public function up()
     {
-        \App\Libraries\Helper\DatabaseLibrary::createUpdatedAtFunction();
+            \App\Libraries\Helper\DatabaseLibrary::createPgsqlUpdatedAtFunction();
     }
 
     public function down()
     {
-        \App\Libraries\Helper\DatabaseLibrary::removeUpdatedAtFunction();
+            \App\Libraries\Helper\DatabaseLibrary::removePgsqlUpdatedAtFunction();
     }
 }


### PR DESCRIPTION
Instead of postgresql, I'm using mysql. I'd also like to not have the base php forked just for minor migrations.
I've added a DatabaseEnum just to give me access to the DB_POSTGRESQL const, this is then used in the migrations to just skip over postgresql specific blocks.
It relies on testing the DB_CONNECTION env variable, thus this const is also used in the databases.php config block, to make sure stuff stays in sync